### PR TITLE
feat: add payment plan modal to patients table

### DIFF
--- a/src/components/patients/PatientsTable.tsx
+++ b/src/components/patients/PatientsTable.tsx
@@ -51,6 +51,7 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
+import PaymentPlanDetailModal from "@/components/PaymentPlanDetailModal";
 
 /* ---------------- Types ---------------- */
 type Risk = "Urgent" | "Normal" | "Low";
@@ -415,6 +416,9 @@ export default function PatientsTable() {
   // Selection (now “visible scope” instead of per-page)
   const [selected, setSelected] = useState<Record<string, boolean>>({});
 
+  // Selected payment plan drawer
+  const [selectedPlan, setSelectedPlan] = useState<PatientRow | null>(null);
+
   // derived clinics for the filter
   const clinics = useMemo(
     () => Array.from(new Set(rows.map((r) => r.clinic))).sort(),
@@ -661,18 +665,19 @@ export default function PatientsTable() {
   }, [recomputeBodyMaxH, activeFilterCount]);
 
   return (
-    <div
-      ref={rootRef}
-      style={{ "--table-body-offset": "38px" } as React.CSSProperties}
-      className="rounded-xl border border-[#e7e4db] bg-white shadow-sm overflow-hidden flex flex-col"
-    >
-      {/* ---------- FIXED TOP: Patients toolbar + chips ---------- */}
-      <div ref={headerRef} className="shrink-0">
-        {/* Title + Controls (desktop first) */}
-        <div className="flex items-center gap-3 px-4 py-3">
-          <h1 className="text-lg font-semibold tracking-[-0.01em] text-gray-900">
-            Patients
-          </h1>
+    <>
+      <div
+        ref={rootRef}
+        style={{ "--table-body-offset": "38px" } as React.CSSProperties}
+        className="rounded-xl border border-[#e7e4db] bg-white shadow-sm overflow-hidden flex flex-col"
+      >
+        {/* ---------- FIXED TOP: Patients toolbar + chips ---------- */}
+        <div ref={headerRef} className="shrink-0">
+          {/* Title + Controls (desktop first) */}
+          <div className="flex items-center gap-3 px-4 py-3">
+            <h1 className="text-lg font-semibold tracking-[-0.01em] text-gray-900">
+              Patients
+            </h1>
 
           <div className="ml-auto flex items-center gap-3">
             {/* FIND CLUSTER (hidden on mobile, shown on md+) */}
@@ -1192,7 +1197,10 @@ export default function PatientsTable() {
                           align="end"
                           className="min-w-[200px]"
                         >
-                          <DropdownMenuItem className="gap-2">
+                          <DropdownMenuItem
+                            className="gap-2"
+                            onSelect={() => setSelectedPlan(r)}
+                          >
                             <Eye className="h-4 w-4" /> View plan
                           </DropdownMenuItem>
                           <DropdownMenuItem className="gap-2">
@@ -1256,34 +1264,41 @@ export default function PatientsTable() {
         })}
       </div>
 
-      {/* ---------- FIXED BOTTOM: footer counts ---------- */}
-      <div
-        ref={footerRef}
-        className="border-t border-[#e6e6e6] px-4 py-2 text-[12px] text-gray-600 flex items-center justify-between"
-      >
-        <div>
-          {total} results • showing {visibleIds.length} on screen
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8"
-            onClick={showAllGroups}
-          >
-            Show all
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8"
-            onClick={showDefaultPerGroup}
-          >
-            Show less
-          </Button>
+        {/* ---------- FIXED BOTTOM: footer counts ---------- */}
+        <div
+          ref={footerRef}
+          className="border-t border-[#e6e6e6] px-4 py-2 text-[12px] text-gray-600 flex items-center justify-between"
+        >
+          <div>
+            {total} results • showing {visibleIds.length} on screen
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              onClick={showAllGroups}
+            >
+              Show all
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              onClick={showDefaultPerGroup}
+            >
+              Show less
+            </Button>
+          </div>
         </div>
       </div>
-    </div>
+
+      <PaymentPlanDetailModal
+        isOpen={!!selectedPlan}
+        onClose={() => setSelectedPlan(null)}
+        paymentPlan={selectedPlan as any}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add PaymentPlanDetailModal import and state to track selected plan
- render modal in PatientsTable and hook up "View plan" action

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b666fb0c8333b0d4282f6fdda9f6