### PR TITLE
Improve landing page mobile responsiveness

### DIFF
--- a/src/components/landing-page/ConsoleShowcase.tsx
+++ b/src/components/landing-page/ConsoleShowcase.tsx
@@ -202,7 +202,7 @@ export default function ConsoleShowcase() {
       <div className="sticky top-0 w-full h-screen flex flex-col justify-center bg-black overflow-hidden">
         {/* Header */}
         <div className="absolute top-10 left-0 right-0 z-20 pt-16 pb-8">
-          <div className="w-full px-8">
+          <div className="w-full px-4 sm:px-6 lg:px-8">
             <header className="text-center">
               <h3 className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-white">
                 The Breeze Console
@@ -216,7 +216,7 @@ export default function ConsoleShowcase() {
         </div>
 
         {/* Cards */}
-        <div className="flex-1 flex items-center justify-center px-8">
+        <div className="flex-1 flex items-center justify-center px-4 sm:px-6 lg:px-8">
           <div className="relative w-full h-[90vh] max-w-8xl">
             {SHOTS.map((shot, index) => {
               if (!renderSet.has(index)) return null;

--- a/src/components/landing-page/Faq.tsx
+++ b/src/components/landing-page/Faq.tsx
@@ -42,7 +42,7 @@ export default function FAQSection() {
   };
 
   return (
-    <section className="w-full py-16 px-4">
+    <section className="w-full py-16 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="mx-auto max-w-4xl text-center mb-14">

--- a/src/components/landing-page/Features.tsx
+++ b/src/components/landing-page/Features.tsx
@@ -8,7 +8,7 @@ import { Body, Surface, TileAsset, Title } from "../SoftCard";
 export default function BreezeBentoSection() {
   return (
     <section className="relative antialiased">
-      <div className="mx-auto max-w-7xl px-6 md:px-8 py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 md:py-24">
         {/* Header */}
         <div className="mx-auto max-w-4xl text-center">
           <h2 className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-slate-800 leading-tight">
@@ -31,11 +31,8 @@ export default function BreezeBentoSection() {
         {/* Bento grid */}
         <div
           className={cn(
-            "mt-12 grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-4",
-            // fixed row units
-            "[--row:92px] md:[--row:100px]",
-            // auto rows + explicit template for stability
-            "[grid-auto-rows:var(--row)] md:[grid-template-rows:repeat(6,var(--row))]"
+            "mt-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-12 gap-4 sm:gap-6",
+            "[grid-auto-rows:auto] md:[--row:100px] md:[grid-auto-rows:var(--row)] md:[grid-template-rows:repeat(6,var(--row))]"
           )}
         >
           {/* 1 — tall left */}

--- a/src/components/landing-page/FeaturesSectionMini.tsx
+++ b/src/components/landing-page/FeaturesSectionMini.tsx
@@ -4,7 +4,7 @@ import { Body, Surface, TileAsset, Title } from "../SoftCard";
 const FeaturesSectionMini = () => {
   return (
     <section className="">
-      <div className="mx-auto max-w-7xl px-4 py-16 md:px-2 md:py-20">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <div className="mx-auto max-w-4xl text-center">
           <h2 className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-slate-800 leading-tight">
             Patient-preferred plans{" "}
@@ -28,8 +28,8 @@ const FeaturesSectionMini = () => {
           className="
             mt-12 grid gap-6
             sm:grid-cols-3
-            [--row:400px]
-            [grid-auto-rows:var(--row)]
+            [grid-auto-rows:auto]
+            sm:[--row:400px] sm:[grid-auto-rows:var(--row)]
           "
         >
           <Surface ariaLabel="More patients say yes">

--- a/src/components/landing-page/Hero.tsx
+++ b/src/components/landing-page/Hero.tsx
@@ -5,7 +5,7 @@ import { RainbowButton } from "../magicui/rainbow-button";
 
 export const Hero = () => {
   return (
-    <section className=" text-slate-900 py-12 sm:py-24 md:py-28 px-4 overflow-hidden pb-0">
+    <section className="text-slate-900 py-12 sm:py-24 md:py-28 px-4 sm:px-6 lg:px-8 overflow-hidden pb-0">
       <div className="mx-auto flex max-w-7xl flex-col gap-12 pt-0 sm:gap-24">
         <div className="flex flex-col items-center gap-6 text-center sm:gap-12">
           {/* Badge */}

--- a/src/components/landing-page/Problems.tsx
+++ b/src/components/landing-page/Problems.tsx
@@ -8,7 +8,7 @@ export default function ProblemsSection() {
   return (
     <section className="py-16 sm:py-20 md:py-24 mt-20">
       {/* Headline */}
-      <div className="text-center mb-12 sm:mb-16 px-4">
+      <div className="text-center mb-12 sm:mb-16 px-4 sm:px-6 lg:px-8">
         <h2
           className="mx-auto max-w-6xl font-semibold tracking-tight text-slate-800 text-pretty leading-[1.05]
                      text-[clamp(32px,6vw,64px)]"
@@ -29,7 +29,7 @@ export default function ProblemsSection() {
         </h2>
       </div>
 
-      <div className="mx-auto max-w-7xl px-4">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div
           className={cn(
             // Responsive grid: stack → 2 cols → 6 cols w/ fixed rows
@@ -251,41 +251,41 @@ function Surface({
   );
 }
 
-/** --- FOOTNOTE LINKS --- */
-function Footnote({
-  href,
-  children,
-}: {
-  href: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        "relative z-[2] mt-auto inline-flex items-center gap-1 text-[11px] tracking-wide",
-        "text-slate-400 hover:text-slate-600 transition-colors underline decoration-slate-200/60 hover:decoration-slate-400"
-      )}
-    >
-      {children}
-      <ExternalIcon />
-    </a>
-  );
-}
-
-function ExternalIcon() {
-  return (
-    <svg viewBox="0 0 20 20" className="h-3.5 w-3.5" aria-hidden>
-      <path
-        d="M11 3h6v6h-2V6.41l-6.3 6.3-1.4-1.42 6.3-6.3H11V3Z"
-        fill="currentColor"
-      />
-      <path d="M5 5h4v2H7v6h6v-2h2v4H5V5Z" fill="currentColor" />
-    </svg>
-  );
-}
+// /** --- FOOTNOTE LINKS --- */
+// function Footnote({
+//   href,
+//   children,
+// }: {
+//   href: string;
+//   children: React.ReactNode;
+// }) {
+//   return (
+//     <a
+//       href={href}
+//       target="_blank"
+//       rel="noopener noreferrer"
+//       className={cn(
+//         "relative z-[2] mt-auto inline-flex items-center gap-1 text-[11px] tracking-wide",
+//         "text-slate-400 hover:text-slate-600 transition-colors underline decoration-slate-200/60 hover:decoration-slate-400"
+//       )}
+//     >
+//       {children}
+//       <ExternalIcon />
+//     </a>
+//   );
+// }
+// 
+// function ExternalIcon() {
+//   return (
+//     <svg viewBox="0 0 20 20" className="h-3.5 w-3.5" aria-hidden>
+//       <path
+//         d="M11 3h6v6h-2V6.41l-6.3 6.3-1.4-1.42 6.3-6.3H11V3Z"
+//         fill="currentColor"
+//       />
+//       <path d="M5 5h4v2H7v6h6v-2h2v4H5V5Z" fill="currentColor" />
+//     </svg>
+//   );
+// }
 
 /** --- DECORATIVE ASSET --- */
 function TileAsset({

--- a/src/components/landing-page/Proof.tsx
+++ b/src/components/landing-page/Proof.tsx
@@ -3,7 +3,7 @@ import { ShieldCheck, CreditCard, FileCheck } from "lucide-react";
 
 export default function ProofSection() {
   return (
-    <section className="px-4 py-14 sm:py-16 md:py-20">
+    <section className="px-4 sm:px-6 lg:px-8 py-14 sm:py-16 md:py-20">
       <div className="mx-auto max-w-7xl">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
           {/* HIPAA */}

--- a/src/components/landing-page/Solution.tsx
+++ b/src/components/landing-page/Solution.tsx
@@ -4,7 +4,7 @@ import HealthcareBNPLProcess from "./Process";
 const Solution = () => {
   return (
     <section id="solution" className="py-24">
-      <div className="container mx-auto px-4 max-w-7xl">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="text-center mb-20">
           <h2 className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-slate-800 leading-tight  text-balance">

--- a/src/components/landing-page/Testimonials.tsx
+++ b/src/components/landing-page/Testimonials.tsx
@@ -24,7 +24,7 @@ function StarSolid({
 
 export default function Testimonials() {
   return (
-    <section className="px-4 py-14 sm:py-16 md:py-20 text-neutral-900">
+    <section className="px-4 sm:px-6 lg:px-8 py-14 sm:py-16 md:py-20 text-neutral-900">
       <div className="mx-auto max-w-7xl">
         {/* Framed surface — now owns all interior spacing */}
         <div

--- a/src/components/magicui/rainbow-button.tsx
+++ b/src/components/magicui/rainbow-button.tsx
@@ -3,9 +3,6 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, VariantProps } from "class-variance-authority";
 import React from "react";
 
-interface RainbowButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
-
 const rainbowButtonVariants = cva(
   cn(
     "relative cursor-pointer group transition-all animate-rainbow",


### PR DESCRIPTION
## Summary
- standardize section padding for mobile breakpoints
- refine feature grids and auto-rows for small viewports
- tighten console showcase spacing for compact screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf593abc688333ad6367f9f76226a7